### PR TITLE
get versions using metadata

### DIFF
--- a/labscript_utils/__init__.py
+++ b/labscript_utils/__init__.py
@@ -10,11 +10,16 @@
 # for the full license.                                             #
 #                                                                   #
 #####################################################################
-from .__version__ import __version__
 
 import sys
 import os
 import traceback
+from pathlib import Path
+
+from .versions import get_version, NoVersionInfo
+__version__ = get_version(__name__, import_path=Path(__file__).parent.parent)
+if __version__ is NoVersionInfo:
+    __version__ = None
 
 PY2 = sys.version_info[0] == 2
 

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,7 @@ except ImportError:
 SETUP_REQUIRES = ['setuptools', 'setuptools_scm']
 
 INSTALL_REQUIRES = [
+    "setuptools_scm",
     "importlib_metadata >=1.0;      python_version < '3.8'",
     "pywin32;                       sys_platform == 'win32'",
     "pyqtgraph",
@@ -74,7 +75,7 @@ else:
 
 setup(
     name='labscript_utils',
-    version=run_path(os.path.join('labscript_utils', '__version__.py'))['__version__'],
+    use_scm_version=True,
     description="Shared utilities for the labscript suite",
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
In setup.py, use setuptools_scm to set the project version
from git tags. If not on a tagged release, it will create
a development version number in a format like:

2.15.1.dev34+g96c8c11.d20200430

Extend labscript_utils.versions.get_version() to first look for git
repository metadata to determine the version of a package, in the case
that it is being imported from a git repository.

Do not hard-code `__version__` - instead determine own version using
a call to get_version().

This means that for a git repository, the single source of truth for the
version is the repository metadata. For an installed package, the single
source of truth is the installation metadata. So long as packages use
the default version format for `setuptools_scm`, the version from a git
repo and then the subsequent installed package should be identical.

Other labscript suite packages may drop their manual version strings and set `use_scm_version=True` in their `setup.py`, and may replace their hard-coded `__version__` attributes with the following in their `__init__.py`:

```python
from pathlib import Path

from labscript_utils.versions import get_version, NoVersionInfo
__version__ = get_version(__name__, import_path=Path(__file__).parent.parent)
if __version__ is NoVersionInfo:
    __version__ = None
```
